### PR TITLE
fix: fix small readme example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const schema = makeExecutableSchema({
   resolvers,
   schemaDirectives: {
     // to use @hasRole and @isAuthenticated directives
-    ...AuthDirective,
+    ...AuthDirective(),
     // custom name for @isAuthenticated
     auth: AuthDirective().isAuthenticated,
     // custom name for @hasRole


### PR DESCRIPTION
The current readme had a typo where the `AuthDirective` module itself was being spread, and not the result of calling `AuthDirective()`.